### PR TITLE
Fix python-novaclient installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Role variables with their default values.
 
 ### OpenStack configuration
 
+* cloud_info_provider_os_release: mitaka
 * cloud_info_provider_os_username: admin
 * cloud_info_provider_os_password: openstack
 * cloud_info_provider_os_auth_url: http://127.0.01:5000/v2.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ cloud_info_provider_sitename: TEST
 cloud_info_provider_conf_dir: /etc/cloud-info-provider-indigo
 cloud_info_provider_main_conf_file: static.yaml
 # OpenStack configuration
+cloud_info_provider_os_release: mitaka
 cloud_info_provider_os_username: admin
 cloud_info_provider_os_password: openstack
 cloud_info_provider_os_auth_url: http://127.0.0.1:5000/v2.0

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,4 +1,11 @@
 ---
+# XXX install before repo as repo's version has broken dependencies
+- name: Install python-novaclient
+  apt:
+    name: python-novaclient
+    state: latest
+  when: cloud_info_provider_middleware == 'openstack'
+
 - name: Install the INDIGO GPG key
   apt_key:
     state: present
@@ -14,9 +21,3 @@
     name: python-cloud-info-provider-indigo
     state: latest
     update_cache: yes
-
-- name: Install python-novaclient
-  apt:
-    name: python-novaclient
-    state: latest
-  when: cloud_info_provider_middleware == 'openstack'

--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -15,6 +15,12 @@
     state: latest
     update_cache: yes
 
+- name: Install OpenStack repositories
+  yum:
+    name: centos-release-openstack-{{ cloud_info_provider_os_release }}
+    state: latest
+  when: cloud_info_provider_middleware == 'openstack'
+
 - name: Install python-novaclient
   yum:
     name: python-novaclient


### PR DESCRIPTION
On Ubuntu python-novaclient should be installed before setting up the INDIGO repository.
On CentOS the OpenStack repositories must be setup before installing it.
