### PR TITLE
debian tasks: no more install python-novaclient explicitely as dependencies have been fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
   # Run the role/playbook with ansible-playbook.
   - ansible-playbook tests/test.yml -i tests/inventory --connection=local --sudo
-  # XXX check if a second pass is needed to have idemptocence (due to travis env)
-  - ansible-playbook tests/test.yml -i tests/inventory --connection=local --sudo
   # Check idempotence, second run shouldn't change anything
   - >
     ansible-playbook tests/test.yml -i tests/inventory --connection=local --sudo

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -17,20 +17,6 @@
     state: latest
     update_cache: yes
 
-# XXX install before INDIGO repo as repo's version has broken dependencies
-- name: Install python-novaclient
-  apt:
-    name: python-novaclient
-    state: latest
-    update_cache: yes
-  when: cloud_info_provider_middleware == 'openstack'
-
-- name: Install python-keystoneclient
-  apt:
-    name: python-keystoneclient
-    state: latest
-  when: cloud_info_provider_middleware == 'openstack'
-
 - name: Install the INDIGO GPG key
   apt_key:
     state: present


### PR DESCRIPTION
debian tasks: no more install python-novaclient explicitely as dependencies have been fixed in the version from INDIGO repositories