### PR TITLE
debian tasks: install python-novaclient only when using openstack midlleware

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -32,3 +32,10 @@
     name: python-cloud-info-provider-indigo
     state: latest
     update_cache: yes
+
+- name: Install python-novaclient
+  apt:
+    name: python-novaclient
+    state: latest
+    update_cache: yes
+  when: cloud_info_provider_middleware == 'openstack'


### PR DESCRIPTION
python-novaclient is an optional dependency of the cloud-info-provider, it is only needed for openstack middleware.